### PR TITLE
Re-encode docs/sfx.txt to UTF-8

### DIFF
--- a/docs/sfx.txt
+++ b/docs/sfx.txt
@@ -1,170 +1,170 @@
 
-������������������������������������������������������������������������������Ŀ
-� SFX Register Usage (all but PC may be used as general purpose registers)     �
-������������������������������������������������������������������������������Ĵ
-� 0  accumulator   � 4  lmult low dest  � 8  merge src low  � 12  loop cnt     �
-� 1  plot x adrs   � 5  		� 9	            � 13  loop adrs    �
-� 2  plot y adrs   � 6  f/lmult src     � 10	            � 14  rom adrs     �
-� 3	           � 7  merge src high  � 11 link rts adrs  � 15  PC           �
-��������������������������������������������������������������������������������
-������������������������������������������������������������������������������Ŀ
-� Add, Subtract, etc.		  Cache Cycles	V S C Z	       Opcode 	       �
-������������������������������������������������������������������������������Ĵ
-� adc Rn	  Rd = Rs + Rn + C	2	* * * *		3D 5n	       �
-� adc #n	  Rd = Rs + #n + C	2	* * * *		3F 5n	       �
-� add Rn	  Rd = Rs + Rn		1	* * * *		5n     	       �
-� add #n	  Rd = Rs + #n		2	* * * *		3E 5n	       �
-� cmp Rn	  Rs - Rn  		2	* * * *		3F 6n 	       �
-� dec Rn  {0:14}  Rn = Rn - 1		1	- * - *		En      {0:14} �
-� inc Rn  {0:14}  Rn = Rn + 1		1	- * - *		Dn      {0:14} �
-� sbc Rn	  Rd = Rs - Rn - C	2	* * * *		3D 6n	       �
-� sub Rn	  Rd = Rs - Rn		1	* * * *		6n	       �
-� sub #n	  Rd = Rs - #n		2	* * * *		3E 6n	       �
-��������������������������������������������������������������������������������
-������������������������������������������������������������������������������Ŀ
-� And, Or, etc.			  Cache Cycles	V S C Z	       Opcode	       �
-������������������������������������������������������������������������������Ĵ
-� and Rn  {1:15}  Rd = Rs & Rn		1	- * - *		7n    	{1:15} �
-� and #n  {1:15}  Rd = Rs & #n		2	- * - *		3E 7n 	{1:15} �
-� bic Rn  {1:15}  Rd = Rs & ~Rn		2	- * - *		3D 7n 	{1:15} �
-� bic #n  {1:15}  Rd = Rs & ~#n		2	- * - *		3F 7n 	{1:15} �
-� not		  Rd = ~Rs		1	- * - *		4F    	       �
-� or  Rn  {1:15}  Rd = Rs ! Rn		1	- * - *		Cn    	{1:15} �
-� or  #n  {1:15}  Rd = Rs ! #n		2	- * - *		3E Cn 	{1:15} �
-� xor Rn  {1:15}  Rd = Rs ^ Rn		2	- * - *		3D Cn 	{1:15} �
-� xor #n  {1:15}  Rd = Rs ^ #n		2	- * - *		3F Cn 	{1:15} �
-��������������������������������������������������������������������������������
-������������������������������������������������������������������������������Ŀ
-� Shifts			  Cache Cycles	V S C Z	       Opcode	       �
-������������������������������������������������������������������������������Ĵ
-� asr		  Rd = asr(Rs)		1	- * * *		96	       �
-� div2		  Rd = asr(Rs) 		2	- * * *		3D 96	       �
-�		    {if -1 then = 0}				   	       �
-� lsr		  Rd = lsr(Rs)		1	- 0 * *		03	       �
-� rol		  Rd = rol(Rs)		1	- * * *		04	       �
-� ror		  Rd = ror(Rs)		1	- * * *		97	       �
-��������������������������������������������������������������������������������
-������������������������������������������������������������������������������Ŀ
-� Multiply {speed set by bit 5 of Config}				       �
-� 			   (Fast) Cache Cycles	V S C Z	       Opcode	       �
-������������������������������������������������������������������������������Ĵ
-� fmult {notR4}	Rd = Rs * R6 {hi word}	4	- * * *		9F	       �
-�      		  C = sign of lo word	        			       �
-� lmult	{notR4}	Rd:R4 = Rs * R6		5	- * * *		3D 9F	       �
-�		  C = sign of lo word	        			       �
-� mult Rn	Rd = Rs{lo, sign ext}	1	- * - *		8n	       �
-�		  * Rn{lo, sign ext}	        		  	       �
-� mult #n	Rd = Rs{lo, sign ext}	2	- * - *		3E 8n	       �
-�		  * #n			        			       �
-� umult Rn	Rd = Rs{lo} * Rn{lo}	2	- * - *		3D 8n	       �
-� umult #n	Rd = Rs{lo} * #n	2	- * - *		3F 8n	       �
-��������������������������������������������������������������������������������
-������������������������������������������������������������������������������Ŀ
-� Load #, Moves	 		 Cache Cycles	V S C Z	       Opcode	       �
-������������������������������������������������������������������������������Ĵ
-� ibt Rn,#xx	Rn = #xx {sign ext}	2	- - - -		An xx	       �
-� iwt Rn,#xxxx	Rn = #xxxx		3	- - - -		Fn xx xx       �
-� hib		Rd = Rs{hi}		1	- * - *		c0	       �
-� link #n {1:4}	R11 = R15 + #n   	1	- - - -		9n    	{1:4}  �
-� lob		Rd = Rs{lo}		1	- * - *		9E	       �
-� merge		Rd = R7{hi}<<8 ! R8{hi} 1	* * * *		70	       �
-�		  S = (b15!b7)		  				       �
-�		  V = (b15!b14!b7!b6)					       �
-�		  C = (b15!b14!b13!b7!b6!b5)				       �
-�		  Z = (b15!b14!b13!b12!b7!b6!b5!b4)			       �
-� move Rm,Rn	Rm = Rn  (with:to)	2	- - - -		2n 1m	       �
-� moves Rm,Rn	Rm = Rn	 (with:from)	2	* * - *		2m Bn	       �
-�		  V = b7						       �
-� ramb		RamB = Rs		2	- - - -		3E DF	       �
-� romb		RomB = Rs		2	- - - -		3F DF	       �
-� sex	        Rd = Rs{lo, sign ext}	1	- * - *		95	       �
-� swap		Rd = Rs{lo}<<8 ! Rs{hi}	1	- * - *		4D	       �
-��������������������������������������������������������������������������������
+┌──────────────────────────────────────────────────────────────────────────────┐
+│ SFX Register Usage (all but PC may be used as general purpose registers)     │
+├──────────────────┬────────────────────┬───────────────────┬──────────────────┤
+│ 0  accumulator   │ 4  lmult low dest  │ 8  merge src low  │ 12  loop cnt     │
+│ 1  plot x adrs   │ 5  		│ 9	            │ 13  loop adrs    │
+│ 2  plot y adrs   │ 6  f/lmult src     │ 10	            │ 14  rom adrs     │
+│ 3	           │ 7  merge src high  │ 11 link rts adrs  │ 15  PC           │
+└──────────────────┴────────────────────┴───────────────────┴──────────────────┘
+┌──────────────────────────────────────────────────────────────────────────────┐
+│ Add, Subtract, etc.		  Cache Cycles	V S C Z	       Opcode 	       │
+├──────────────────────────────────────────────────────────────────────────────┤
+│ adc Rn	  Rd = Rs + Rn + C	2	* * * *		3D 5n	       │
+│ adc #n	  Rd = Rs + #n + C	2	* * * *		3F 5n	       │
+│ add Rn	  Rd = Rs + Rn		1	* * * *		5n     	       │
+│ add #n	  Rd = Rs + #n		2	* * * *		3E 5n	       │
+│ cmp Rn	  Rs - Rn  		2	* * * *		3F 6n 	       │
+│ dec Rn  {0:14}  Rn = Rn - 1		1	- * - *		En      {0:14} │
+│ inc Rn  {0:14}  Rn = Rn + 1		1	- * - *		Dn      {0:14} │
+│ sbc Rn	  Rd = Rs - Rn - C	2	* * * *		3D 6n	       │
+│ sub Rn	  Rd = Rs - Rn		1	* * * *		6n	       │
+│ sub #n	  Rd = Rs - #n		2	* * * *		3E 6n	       │
+└──────────────────────────────────────────────────────────────────────────────┘
+┌──────────────────────────────────────────────────────────────────────────────┐
+│ And, Or, etc.			  Cache Cycles	V S C Z	       Opcode	       │
+├──────────────────────────────────────────────────────────────────────────────┤
+│ and Rn  {1:15}  Rd = Rs & Rn		1	- * - *		7n    	{1:15} │
+│ and #n  {1:15}  Rd = Rs & #n		2	- * - *		3E 7n 	{1:15} │
+│ bic Rn  {1:15}  Rd = Rs & ~Rn		2	- * - *		3D 7n 	{1:15} │
+│ bic #n  {1:15}  Rd = Rs & ~#n		2	- * - *		3F 7n 	{1:15} │
+│ not		  Rd = ~Rs		1	- * - *		4F    	       │
+│ or  Rn  {1:15}  Rd = Rs ! Rn		1	- * - *		Cn    	{1:15} │
+│ or  #n  {1:15}  Rd = Rs ! #n		2	- * - *		3E Cn 	{1:15} │
+│ xor Rn  {1:15}  Rd = Rs ^ Rn		2	- * - *		3D Cn 	{1:15} │
+│ xor #n  {1:15}  Rd = Rs ^ #n		2	- * - *		3F Cn 	{1:15} │
+└──────────────────────────────────────────────────────────────────────────────┘
+┌──────────────────────────────────────────────────────────────────────────────┐
+│ Shifts			  Cache Cycles	V S C Z	       Opcode	       │
+├──────────────────────────────────────────────────────────────────────────────┤
+│ asr		  Rd = asr(Rs)		1	- * * *		96	       │
+│ div2		  Rd = asr(Rs) 		2	- * * *		3D 96	       │
+│		    {if -1 then = 0}				   	       │
+│ lsr		  Rd = lsr(Rs)		1	- 0 * *		03	       │
+│ rol		  Rd = rol(Rs)		1	- * * *		04	       │
+│ ror		  Rd = ror(Rs)		1	- * * *		97	       │
+└──────────────────────────────────────────────────────────────────────────────┘
+┌──────────────────────────────────────────────────────────────────────────────┐
+│ Multiply {speed set by bit 5 of Config}				       │
+│ 			   (Fast) Cache Cycles	V S C Z	       Opcode	       │
+├──────────────────────────────────────────────────────────────────────────────┤
+│ fmult {notR4}	Rd = Rs * R6 {hi word}	4	- * * *		9F	       │
+│      		  C = sign of lo word	        			       │
+│ lmult	{notR4}	Rd:R4 = Rs * R6		5	- * * *		3D 9F	       │
+│		  C = sign of lo word	        			       │
+│ mult Rn	Rd = Rs{lo, sign ext}	1	- * - *		8n	       │
+│		  * Rn{lo, sign ext}	        		  	       │
+│ mult #n	Rd = Rs{lo, sign ext}	2	- * - *		3E 8n	       │
+│		  * #n			        			       │
+│ umult Rn	Rd = Rs{lo} * Rn{lo}	2	- * - *		3D 8n	       │
+│ umult #n	Rd = Rs{lo} * #n	2	- * - *		3F 8n	       │
+└──────────────────────────────────────────────────────────────────────────────┘
+┌──────────────────────────────────────────────────────────────────────────────┐
+│ Load #, Moves	 		 Cache Cycles	V S C Z	       Opcode	       │
+├──────────────────────────────────────────────────────────────────────────────┤
+│ ibt Rn,#xx	Rn = #xx {sign ext}	2	- - - -		An xx	       │
+│ iwt Rn,#xxxx	Rn = #xxxx		3	- - - -		Fn xx xx       │
+│ hib		Rd = Rs{hi}		1	- * - *		c0	       │
+│ link #n {1:4}	R11 = R15 + #n   	1	- - - -		9n    	{1:4}  │
+│ lob		Rd = Rs{lo}		1	- * - *		9E	       │
+│ merge		Rd = R7{hi}<<8 ! R8{hi} 1	* * * *		70	       │
+│		  S = (b15!b7)		  				       │
+│		  V = (b15!b14!b7!b6)					       │
+│		  C = (b15!b14!b13!b7!b6!b5)				       │
+│		  Z = (b15!b14!b13!b12!b7!b6!b5!b4)			       │
+│ move Rm,Rn	Rm = Rn  (with:to)	2	- - - -		2n 1m	       │
+│ moves Rm,Rn	Rm = Rn	 (with:from)	2	* * - *		2m Bn	       │
+│		  V = b7						       │
+│ ramb		RamB = Rs		2	- - - -		3E DF	       │
+│ romb		RomB = Rs		2	- - - -		3F DF	       │
+│ sex	        Rd = Rs{lo, sign ext}	1	- * - *		95	       │
+│ swap		Rd = Rs{lo}<<8 ! Rs{hi}	1	- * - *		4D	       │
+└──────────────────────────────────────────────────────────────────────────────┘
 
 
-������������������������������������������������������������������������������Ŀ
-� Read Ram			  Cache Cycles	V S C Z	       Opcode	       �
-������������������������������������������������������������������������������Ĵ
-� ldb (Rn)  {0:11}  Rd = (Rn){byte}  	8	- - - -		3D 4n 	{0:11} �
-� ldw (Rn)  {0:11}  Rd = (Rn){word}  	11	- - - -		4n    	{0:11} �
-� lm  Rn,(xxxx)     Rn = (xxxx){word}	14	- - - -		3D Fn xx xx    �
-� lms Rn,(xxx)	    Rn = (xxx){word}	13	- - - -		3D An xxx/2    �
-�		      {xxx = 0,2,...,510}    				       �
-��������������������������������������������������������������������������������
+┌──────────────────────────────────────────────────────────────────────────────┐
+│ Read Ram			  Cache Cycles	V S C Z	       Opcode	       │
+├──────────────────────────────────────────────────────────────────────────────┤
+│ ldb (Rn)  {0:11}  Rd = (Rn){byte}  	8	- - - -		3D 4n 	{0:11} │
+│ ldw (Rn)  {0:11}  Rd = (Rn){word}  	11	- - - -		4n    	{0:11} │
+│ lm  Rn,(xxxx)     Rn = (xxxx){word}	14	- - - -		3D Fn xx xx    │
+│ lms Rn,(xxx)	    Rn = (xxx){word}	13	- - - -		3D An xxx/2    │
+│		      {xxx = 0,2,...,510}    				       │
+└──────────────────────────────────────────────────────────────────────────────┘
 
 
-������������������������������������������������������������������������������Ŀ
-� Write Ram			  Cache Cycles	V S C Z	       Opcode	       �
-������������������������������������������������������������������������������Ĵ
-� sbk		    (last ram adrs)	1:10	- - - -		90	       �
-�		      = Rs{word}	  			  	       �
-� sm  (xxxx),Rn     (xxxx) = Rn{word}	4:12	- - - -		3E Fn xx xx    �
-� sms (xxx),Rn	    (xxx) = Rn{word}	3:11	- - - -		3E An xxx/2    �
-�		      {xxx = 0,2,...,510}			  	       �
-� stb (Rn)  {0:11}  (Rn) = Rs{byte}  	2:6	- - - -		3D 3n 	{0:11} �
-� stw (Rn)  {0:11}  (Rn) = Rs{word}  	1:10	- - - -		3n    	{0:11} �
-��������������������������������������������������������������������������������
+┌──────────────────────────────────────────────────────────────────────────────┐
+│ Write Ram			  Cache Cycles	V S C Z	       Opcode	       │
+├──────────────────────────────────────────────────────────────────────────────┤
+│ sbk		    (last ram adrs)	1:10	- - - -		90	       │
+│		      = Rs{word}	  			  	       │
+│ sm  (xxxx),Rn     (xxxx) = Rn{word}	4:12	- - - -		3E Fn xx xx    │
+│ sms (xxx),Rn	    (xxx) = Rn{word}	3:11	- - - -		3E An xxx/2    │
+│		      {xxx = 0,2,...,510}			  	       │
+│ stb (Rn)  {0:11}  (Rn) = Rs{byte}  	2:6	- - - -		3D 3n 	{0:11} │
+│ stw (Rn)  {0:11}  (Rn) = Rs{word}  	1:10	- - - -		3n    	{0:11} │
+└──────────────────────────────────────────────────────────────────────────────┘
 
 
-������������������������������������������������������������������������������Ŀ
-� Read Rom, Write Color		  Cache Cycles	V S C Z	       Opcode	       �
-������������������������������������������������������������������������������Ĵ
-� color		Color = Rs		1	- - - -		4E	       �
-� getc		Color = RomBuf		1:8	- - - -		DF	       �
-� getb		Rd = RomBuf		1:8  	- - - -		EF	       �
-� getbh		Rd = RomBuf<<8 ! Rs{lo} 2:8   	- - - -		3D EF	       �
-� getbl		Rd = Rs{hi}<<8 ! RomBuf	2:8	- - - -		3E EF	       �
-� getbs		Rd = RomBuf {sign ext}	2:8	- - - -		3F EF	       �
-��������������������������������������������������������������������������������
-������������������������������������������������������������������������������Ŀ
-� Branches etc.	 {if branch etc. done, then following pipeline byte executed}  �
-�   xx = -128:127,							       �
-�   if branch: R15 = R15 + xx	  Cache Cycles	V S C Z	       Opcode 	       �
-������������������������������������������������������������������������������Ĵ
-� bcs xx	  if C=1, branch	2	- - - -		0D xx	       �
-� bcc xx	  if C=0, branch	2	- - - -		0C xx	       �
-� beq xx	  if Z=1, branch	2	- - - -		09 xx	       �
-� bne xx	  if Z=0, branch	2	- - - -		08 xx	       �
-� bmi xx	  if S=1, branch	2	- - - -		0B xx	       �
-� bpl xx	  if S=0, branch	2	- - - -		0A xx	       �
-� bvs xx	  if V=1, branch	2	- - - -		0F xx	       �
-� bvc xx	  if V=0, branch	2	- - - -		0E xx	       �
-� blt xx	  if (S ^ V)=1, branch	2	- - - -		07 xx	       �
-� bge xx	  if (S ^ V)=0, branch	2	- - - -		06 xx	       �
-� bra xx	  branch    		2	- - - -		05 xx	       �
-� jmp  Rn {8:13}  R15 = Rn		1	- - - -		9n    	{8:13} �
-� ljmp Rn {8:13}  PCB:R15 = Rn:Rs 	2	- - - -		3D 9n 	{8:13} �
-�		    CBR = Rs & 0fff0h					       �
-�		    cache flags cleared					       �
-� loop	          R12 = R12 - 1, then	1	- * - *		3C	       �
-�	            if Z=0, R15 = R13   			  	       �
-��������������������������������������������������������������������������������
+┌──────────────────────────────────────────────────────────────────────────────┐
+│ Read Rom, Write Color		  Cache Cycles	V S C Z	       Opcode	       │
+├──────────────────────────────────────────────────────────────────────────────┤
+│ color		Color = Rs		1	- - - -		4E	       │
+│ getc		Color = RomBuf		1:8	- - - -		DF	       │
+│ getb		Rd = RomBuf		1:8  	- - - -		EF	       │
+│ getbh		Rd = RomBuf<<8 ! Rs{lo} 2:8   	- - - -		3D EF	       │
+│ getbl		Rd = Rs{hi}<<8 ! RomBuf	2:8	- - - -		3E EF	       │
+│ getbs		Rd = RomBuf {sign ext}	2:8	- - - -		3F EF	       │
+└──────────────────────────────────────────────────────────────────────────────┘
+┌──────────────────────────────────────────────────────────────────────────────┐
+│ Branches etc.	 {if branch etc. done, then following pipeline byte executed}  │
+│   xx = -128:127,							       │
+│   if branch: R15 = R15 + xx	  Cache Cycles	V S C Z	       Opcode 	       │
+├──────────────────────────────────────────────────────────────────────────────┤
+│ bcs xx	  if C=1, branch	2	- - - -		0D xx	       │
+│ bcc xx	  if C=0, branch	2	- - - -		0C xx	       │
+│ beq xx	  if Z=1, branch	2	- - - -		09 xx	       │
+│ bne xx	  if Z=0, branch	2	- - - -		08 xx	       │
+│ bmi xx	  if S=1, branch	2	- - - -		0B xx	       │
+│ bpl xx	  if S=0, branch	2	- - - -		0A xx	       │
+│ bvs xx	  if V=1, branch	2	- - - -		0F xx	       │
+│ bvc xx	  if V=0, branch	2	- - - -		0E xx	       │
+│ blt xx	  if (S ^ V)=1, branch	2	- - - -		07 xx	       │
+│ bge xx	  if (S ^ V)=0, branch	2	- - - -		06 xx	       │
+│ bra xx	  branch    		2	- - - -		05 xx	       │
+│ jmp  Rn {8:13}  R15 = Rn		1	- - - -		9n    	{8:13} │
+│ ljmp Rn {8:13}  PCB:R15 = Rn:Rs 	2	- - - -		3D 9n 	{8:13} │
+│		    CBR = Rs & 0fff0h					       │
+│		    cache flags cleared					       │
+│ loop	          R12 = R12 - 1, then	1	- * - *		3C	       │
+│	            if Z=0, R15 = R13   			  	       │
+└──────────────────────────────────────────────────────────────────────────────┘
 
 
-������������������������������������������������������������������������������Ŀ
-� Misc.				  Cache Cycles	V S C Z	       Opcode	       �
-������������������������������������������������������������������������������Ĵ
-� from Rn      set Rs {after 'with':	1	- - - -		Bn	       �
-�	         becomes 'moves'}				  	       �
-� to   Rn      set Rd {after 'with':	1	- - - -		1n	       �
-�	         becomes 'move'}				  	       �
-� with Rn      set Rs, Rd {before a	1	- - - -		2n	       �
-�	         'to' or 'from': becomes			  	       �
-�	         'move' or 'moves'}				  	       �
-� plot	       plot Color at (R1,R2),	1:80	- - - -		4C	       �
-�	         R1 = R1 + 1						       �
-� rpix	       Rd = pixel at (R1,R2)	?:?	- * - *		3D 4C	       �
-� alt1	       misc. opcode prefix	1	- - - -		3D	       �
-� 		 {after alt2: alt3}					       �
-� alt2	       misc. opcode prefix	1	- - - -		3E	       �
-� 		 {after alt1: alt3}					       �
-� alt3	       misc. opcode prefix	1	- - - -		3F	       �
-� cache	       if CBR ~= (R15 & 0fff0h)	1	- - - -		02	       �
-�  	       then CBR = R15 & 0fff0h)					       �
-�  	            cache flags cleared					       �
-� cmode	       PlotOpt = Rs		2	- - - -		3D 4E	       �
-� nop	       {will zap 'with' etc.}	1	- - - -		01	       �
-� stop	       GoFlag = 0, 		1	- - - -		00	       �
-�		 make SNES IRQ						       �
-��������������������������������������������������������������������������������
+┌──────────────────────────────────────────────────────────────────────────────┐
+│ Misc.				  Cache Cycles	V S C Z	       Opcode	       │
+├──────────────────────────────────────────────────────────────────────────────┤
+│ from Rn      set Rs {after 'with':	1	- - - -		Bn	       │
+│	         becomes 'moves'}				  	       │
+│ to   Rn      set Rd {after 'with':	1	- - - -		1n	       │
+│	         becomes 'move'}				  	       │
+│ with Rn      set Rs, Rd {before a	1	- - - -		2n	       │
+│	         'to' or 'from': becomes			  	       │
+│	         'move' or 'moves'}				  	       │
+│ plot	       plot Color at (R1,R2),	1:80	- - - -		4C	       │
+│	         R1 = R1 + 1						       │
+│ rpix	       Rd = pixel at (R1,R2)	?:?	- * - *		3D 4C	       │
+│ alt1	       misc. opcode prefix	1	- - - -		3D	       │
+│ 		 {after alt2: alt3}					       │
+│ alt2	       misc. opcode prefix	1	- - - -		3E	       │
+│ 		 {after alt1: alt3}					       │
+│ alt3	       misc. opcode prefix	1	- - - -		3F	       │
+│ cache	       if CBR ~= (R15 & 0fff0h)	1	- - - -		02	       │
+│  	       then CBR = R15 & 0fff0h)					       │
+│  	            cache flags cleared					       │
+│ cmode	       PlotOpt = Rs		2	- - - -		3D 4E	       │
+│ nop	       {will zap 'with' etc.}	1	- - - -		01	       │
+│ stop	       GoFlag = 0, 		1	- - - -		00	       │
+│		 make SNES IRQ						       │
+└──────────────────────────────────────────────────────────────────────────────┘
 


### PR DESCRIPTION
This PR will make the SFX registers documentation legible in modern browsers.

Command used to generate the aforementioned output:
`iconv -f IBM850 -t UTF-8 -o sfx.utf8.txt sfx.txt && mv sfx.utf8.txt sfx.txt`

Closes #1 

Thanks!